### PR TITLE
Update and changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,12 +56,12 @@ jobs:
 
       - name: Rename executable (Windows)
         if: matrix.os == 'windows-latest'
-        run: mv target/${{ matrix.target }}/release/emil.exe ${{ matrix.artifact-name }}
+        run: mv target/${{ matrix.target }}/release/npwg.exe ${{ matrix.artifact-name }}
         shell: bash
 
       - name: Rename executable (Linux/macOS)
         if: matrix.os != 'windows-latest'
-        run: mv target/${{ matrix.target }}/release/emil ${{ matrix.artifact-name }}
+        run: mv target/${{ matrix.target }}/release/npwg ${{ matrix.artifact-name }}
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Regression tests covering pronounceable output, mutation workflows, clipboard failures, and CLI argument parsing.
 - Explicit error variants for wordlist validation failures and clipboard availability.
 - Optional configuration file with reusable profiles (`--config`, `--profile`).
+- Built-in password policies (`--policy windows-ad|pci-dss|nist-high`) with hardening guidance.
 
 ### Changed
 - GitHub Actions release workflow now publishes `npwg` binaries directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.6] - 2025-05-27
 ### Added
 - Regression tests covering pronounceable output, mutation workflows, clipboard failures, and CLI argument parsing.
 - Explicit error variants for wordlist validation failures and clipboard availability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - Regression tests covering pronounceable output, mutation workflows, clipboard failures, and CLI argument parsing.
 - Explicit error variants for wordlist validation failures and clipboard availability.
+- Optional configuration file with reusable profiles (`--config`, `--profile`).
 
 ### Changed
 - GitHub Actions release workflow now publishes `npwg` binaries directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,173 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Regression tests covering pronounceable output, mutation workflows, clipboard failures, and CLI argument parsing.
+- Explicit error variants for wordlist validation failures and clipboard availability.
+
+### Changed
+- GitHub Actions release workflow now publishes `npwg` binaries directly.
+- Diceware downloads apply network timeouts, checksum validation, and clearer recovery guidance.
+- Clipboard integration surfaces actionable errors and rejects empty copy requests.
+- README usage examples consolidated with dedicated pattern and mutation sections.
+- Dependency stack refreshed to latest patch releases (reqwest, arboard, openssl, etc.).
+
+## [0.4.5] - 2025-05-21
+### Added
+- Pattern validation utilities (`src/bin/test_pattern*.rs`) and extensive async tests that exercise generator edge cases.
+- Richer mutation tooling with optional mutation-type overrides, configurable strength, and clearer output formatting.
+### Changed
+- Password, diceware, and pronounceable generators now propagate errors consistently to the CLI layer.
+- Strength and statistics reporting refined to deliver clearer feedback and improvement suggestions.
+### Fixed
+- Resolved silent failure cases when generation encountered invalid configuration or clipboard access errors.
+
+## [0.4.4] - 2025-02-26
+### Added
+- Improvement suggestions for weak and moderate passwords directly in the strength meter output.
+### Changed
+- Strength evaluation internals tuned for more accurate scoring and user guidance.
+### Fixed
+- Updated dependency stack and tightened workflow permissions to address security alerts.
+
+## [0.4.3] - 2025-02-23
+### Added
+- Dedicated `interactive` module that encapsulates the interactive CLI flow and supporting helpers.
+### Changed
+- Streamlined the main binary by moving interactive logic into the new module and cleaning unused imports.
+
+## [0.4.2] - 2025-02-11
+### Changed
+- Adjusted GitHub Actions release workflow and refreshed dependency versions for stability.
+### Fixed
+- Resolved CI permissions and ensured build artifacts publish correctly across platforms.
+
+## [0.4.1] - 2025-01-28
+### Added
+- Optional `--seed` flag wiring to allow deterministic password generation for testing and reproducibility.
+### Changed
+- Upgraded the randomness stack (`rand`, `rand_distr`) and runtime dependencies (`tokio`, `dirs`, `colored`, `thiserror`, `serde`, `reqwest`) to latest releases.
+
+## [0.4.0] - 2024-12-24
+### Added
+- Pattern-driven password generation mode enabling templates such as `LLDDS` for precise control over character classes.
+### Changed
+- Updated dependency tree after introducing pattern support.
+
+## [0.3.7] - 2024-11-16
+### Changed
+- Routine dependency refresh across networking, regex, and error-handling crates to maintain security posture.
+
+## [0.3.6] - 2024-10-11
+### Added
+- Clipboard daemonization on Linux to ensure copies persist after the CLI exits.
+### Changed
+- Swapped the clipboard backend to `arboard` for better cross-platform support and improved error handling.
+
+## [0.3.5] - 2024-10-09
+### Added
+- Password strength meter (`--strength`) with entropy scoring and guidance.
+- Password mutation modes, including lengthening, replacements, and interactive previews.
+- Clipboard integration for copying generated secrets directly from the CLI.
+### Changed
+- Expanded tests around configuration parsing and generation routines.
+- Updated documentation to cover the new strength and mutation flows.
+
+## [0.3.4] - 2024-10-04
+### Added
+- Initial strength analysis module and mutation helpers for password tweaking.
+- Additional configuration tests improving coverage of character set handling.
+### Changed
+- Refined CLI help text and README examples for the new features.
+
+## [0.3.3] - 2024-09-23
+### Added
+- Pronounceable password generator mode and optimizations to diceware passphrase creation.
+### Changed
+- CLI wiring to expose the new generation modes.
+
+## [0.3.2] - 2024-09-15
+### Added
+- Configurable diceware separators (explicit character or random) with accompanying docs.
+### Changed
+- Diceware configuration to honour the separator option across outputs.
+
+## [0.3.1] - 2024-09-10
+### Changed
+- Dependency refresh across `clap`, `dashmap`, and `serde`.
+
+## [0.3.0] - 2024-09-03
+### Added
+- Interactive console mode built with `dialoguer`, enabling guided password generation.
+
+## [0.2.7] - 2024-08-31
+### Added
+- Optional avoidance of repeating characters and improved diceware passphrase assembly.
+- Automatic diceware wordlist download via `reqwest` when missing.
+### Changed
+- General password generation tuning and dependency updates.
+
+## [0.2.6] - 2024-08-23
+### Added
+- Library-friendly API surface in `lib.rs` exposing generation helpers to external consumers.
+
+## [0.2.5] - 2024-08-20
+### Changed
+- Dependency maintenance across `tokio`, `clap`, `serde`, and `reqwest` crates.
+
+## [0.2.4] - 2024-08-13
+### Changed
+- Continued dependency updates (clap, serde, regex, tokio, thiserror, openssl) alongside CI workflow tweaks.
+
+## [0.2.3] - 2024-07-09
+### Changed
+- Updated `serde` dependency to the latest patch release.
+
+## [0.2.2] - 2024-07-01
+### Added
+- Diceware wordlist download and caching plus improved error reporting throughout generation flows.
+### Changed
+- Configuration revamped to build character sets from predefined definitions; dependency updates across the stack.
+
+## [0.2.1] - 2024-06-21
+### Changed
+- README refreshed to document the expanding feature set.
+
+## [0.2.0] - 2024-06-20
+### Added
+- Diceware passphrase generation in both CLI and library layers.
+- Async/await refactor for password and diceware generation functions.
+### Changed
+- Dependency upgrades to support async workflows and diceware support.
+
+## [0.1.6] - 2024-06-07
+### Added
+- Dependabot automation for cargo dependencies.
+### Changed
+- Updated runtime dependencies (`tokio`, `zeroize`) and crate metadata.
+
+## [0.1.5] - 2024-04-14
+### Added
+- Repository metadata to `Cargo.toml` for crates.io visibility.
+
+## [0.1.4] - 2024-04-14
+### Fixed
+- Corrected default CLI values after initial feedback.
+
+## [0.1.3] - 2024-04-14
+### Added
+- `--avoid-repeating` flag and extended character set options with OS RNG support.
+### Changed
+- Dependency updates accompanying the new CLI knobs.
+
+## [0.1.2] - 2024-04-13
+### Added
+- Additional predefined character sets and build workflow improvements.
+
+## [0.1.0] - 2024-04-12
+### Added
+- Initial release of `npwg` with configurable secure password generation via CLI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,8 +1203,10 @@ dependencies = [
  "reqwest",
  "serde",
  "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "zeroize",
 ]
 
@@ -1811,6 +1813,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2083,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2611,6 +2663,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "npwg"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "arboard",
  "chacha20",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,44 +43,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "arboard"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f533f8e0af236ffe5eb979b99381df3258853f00ba2e44b6e1955292c75227"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
  "clipboard-win",
  "image",
@@ -92,7 +92,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -105,9 +105,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -132,15 +132,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
-name = "bitflags"
-version = "2.9.1"
+name = "block-buffer"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-padding"
@@ -153,15 +156,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder-lite"
@@ -177,18 +180,19 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chacha20"
@@ -214,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -224,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -248,24 +252,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "clipboard-win"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -316,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -328,6 +332,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -366,6 +376,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,7 +412,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "objc2",
 ]
 
@@ -436,12 +456,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -457,6 +477,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,9 +519,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -504,9 +550,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -612,12 +658,12 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.4.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
 dependencies = [
- "libc",
- "windows-targets 0.48.5",
+ "rustix 1.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -628,7 +674,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -640,7 +686,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -651,9 +697,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -669,6 +715,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,9 +732,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -728,19 +784,21 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -748,11 +806,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -781,13 +838,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.12"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -796,7 +854,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -892,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -913,12 +971,13 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.6"
+version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
+checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "moxcms",
  "num-traits",
  "png",
  "tiff",
@@ -926,12 +985,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -946,11 +1005,11 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -984,16 +1043,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jpeg-decoder"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
-
-[[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1001,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libm"
@@ -1013,11 +1066,11 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "libc",
 ]
 
@@ -1029,9 +1082,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1041,9 +1094,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1051,15 +1104,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -1075,9 +1128,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1085,13 +1138,23 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1139,6 +1202,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
+ "sha2",
  "thiserror",
  "tokio",
  "zeroize",
@@ -1156,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+checksum = "561f357ba7f3a2a61563a186a163d0a3a5247e1089524a3981d49adb775078bc"
 dependencies = [
  "objc2-encode",
 ]
@@ -1169,7 +1233,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -1181,7 +1245,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "dispatch2",
  "objc2",
 ]
@@ -1192,7 +1256,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -1211,7 +1275,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1222,7 +1286,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1243,12 +1307,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.72"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1276,9 +1346,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.108"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1294,9 +1364,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_pipe"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
+checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1304,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1314,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1327,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -1361,11 +1431,11 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
-version = "0.17.16"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1374,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -1392,12 +1462,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f9b339b02259ada5c0f4a389b7fb472f933aa17ce176fd2ad98f28bb401fde"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -1419,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1464,18 +1549,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -1484,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1496,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1507,15 +1592,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",
@@ -1569,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
@@ -1579,7 +1664,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1588,22 +1673,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1623,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1634,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1646,11 +1731,11 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1665,7 +1750,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1674,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1684,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.224"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1694,18 +1779,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.224"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.224"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1714,14 +1799,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1734,6 +1820,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1750,9 +1847,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -1765,28 +1862,15 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
-
-[[package]]
-name = "socket2"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -1818,9 +1902,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1853,7 +1937,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -1870,31 +1954,31 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1903,13 +1987,16 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.9.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
 dependencies = [
+ "fax",
  "flate2",
- "jpeg-decoder",
+ "half",
+ "quick-error",
  "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1937,7 +2024,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -1965,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
 dependencies = [
  "rustls",
  "tokio",
@@ -1975,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2003,11 +2090,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -2043,20 +2130,19 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "tree_magic_mini"
-version = "3.1.6"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac5e8971f245c3389a5a76e648bfc80803ae066a1243a75db0064d7c1129d63"
+checksum = "f943391d896cdfe8eec03a04d7110332d445be7df856db382dd96a730667562c"
 dependencies = [
- "fnv",
  "memchr",
  "nom",
  "once_cell",
@@ -2077,15 +2163,15 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "untrusted"
@@ -2095,13 +2181,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2139,36 +2226,46 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
 dependencies = [
  "bumpalo",
  "log",
@@ -2180,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2193,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2203,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2216,45 +2313,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe770181423e5fc79d3e2a7f4410b7799d5aab1de4372853de3c6aa13ca24121"
+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 0.38.44",
+ "rustix 1.1.2",
  "smallvec",
  "wayland-sys",
 ]
 
 [[package]]
 name = "wayland-client"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978fa7c67b0847dbd6a9f350ca2569174974cd4082737054dbb7fbb79d7d9a61"
+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
- "bitflags 2.9.1",
- "rustix 0.38.44",
+ "bitflags",
+ "rustix 1.1.2",
  "wayland-backend",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.8"
+version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779075454e1e9a521794fed15886323ea0feda3f8b0fc1390f5398141310422a"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2262,11 +2359,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb6cdc73399c0e06504c437fe3cf886f25568dd5454473d565085b36d6a8bbf"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2275,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2286,18 +2383,18 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
 dependencies = [
  "pkg-config",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2305,15 +2402,15 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -2323,13 +2420,13 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
- "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -2338,16 +2435,16 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link 0.1.1",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link 0.1.1",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2370,26 +2467,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
  "windows-link 0.2.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2410,10 +2501,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2423,12 +2515,6 @@ dependencies = [
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2444,12 +2530,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2459,12 +2539,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2492,12 +2566,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2507,12 +2575,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2528,12 +2590,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2543,12 +2599,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2563,13 +2613,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.1",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wl-clipboard-rs"
@@ -2598,20 +2645,20 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "x11rb"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix 0.38.44",
+ "rustix 1.1.2",
  "x11rb-protocol",
 ]
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yoke"
@@ -2639,18 +2686,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2697,9 +2744,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2715,4 +2762,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ thiserror = "2.0.12"
 dialoguer = "0.12.0"
 console = "0.16.1"
 arboard = { version = "3.6.0", features = ["wl-clipboard-rs"] }
+sha2 = "0.10"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
+[[bin]]
+name = "npwg"
+path = "src/main.rs"
+
 [package]
 name = "npwg"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 license = "MIT"
-authors = ["Volker Schwaberow <volker@schwaberow.de>"]
+authors = [ "Volker Schwaberow <volker@schwaberow.de>",]
 description = "Securely generate random passwords"
 repository = "https://github.com/vschwaberow/npwg"
 
@@ -11,35 +15,50 @@ repository = "https://github.com/vschwaberow/npwg"
 name = "npwg"
 path = "src/lib.rs"
 
-[[bin]]
-name = "npwg"
-path = "src/main.rs"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-rand = { version = "0.9.2", features = ["std", "small_rng"] }
 regex = "1.11.1"
-chacha20 = { version = "0.9.1", features = ["std", "zeroize"] }
-clap = { version = "4.5.47", features = ["cargo", "env", "derive"] }
 zeroize = "1.8.1"
-tokio = { version = "1.47.1", features = ["full"] }
 dashmap = "6.1.0"
 rand_distr = "0.5"
 dirs = "6.0.0"
-reqwest = { version = "0.12.22", features = ["blocking"] }
 futures = "0.3.31"
 colored = "3.0.0"
-serde = { version = "1.0.224", features = ["derive"] }
 thiserror = "2.0.12"
 dialoguer = "0.12.0"
 console = "0.16.1"
-arboard = { version = "3.6.0", features = ["wl-clipboard-rs"] }
 sha2 = "0.10"
 toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3.12"
+
+[dependencies.rand]
+version = "0.9.2"
+features = [ "std", "small_rng",]
+
+[dependencies.chacha20]
+version = "0.9.1"
+features = [ "std", "zeroize",]
+
+[dependencies.clap]
+version = "4.5.47"
+features = [ "cargo", "env", "derive",]
+
+[dependencies.tokio]
+version = "1.47.1"
+features = [ "full",]
+
+[dependencies.reqwest]
+version = "0.12.22"
+features = [ "blocking",]
+
+[dependencies.serde]
+version = "1.0.224"
+features = [ "derive",]
+
+[dependencies.arboard]
+version = "3.6.0"
+features = [ "wl-clipboard-rs",]
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ dialoguer = "0.12.0"
 console = "0.16.1"
 arboard = { version = "3.6.0", features = ["wl-clipboard-rs"] }
 sha2 = "0.10"
+toml = "0.8"
+
+[dev-dependencies]
+tempfile = "3.12"
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ Provide a custom config path when needed:
 npwg --config ./fixtures/npwg.toml --profile personal
 ```
 
+Use built-in policies for common compliance regimes; these enforce minimum length and character-set expectations before applying your overrides:
+
+```sh
+npwg --policy windows-ad
+npwg --policy pci-dss --count 10
+```
+
 ## Contributing
 
 Contributions are welcome! If you find a bug or have a suggestion for improvement, please open an issue or submit a pull request.

--- a/README.md
+++ b/README.md
@@ -80,102 +80,109 @@ npwg [OPTIONS]
 - `slashes`, `brackets`, `punctuation`: Specific character types
 - `all`, `allprint`, `allprintnoquote`, etc.: Various combinations of character types
 
-### Examples
+### Example Recipes
 
-Use the interactive mode
-```sh
-npwg -i
-```
-or
-```sh
-npwg --interactive
-```
+#### Quick Passwords
 
-Generate a password with the default length (16 characters):
+Generate default credentials:
+
 ```sh
 npwg
 ```
 
-Generate a password with a specific length:
-```sh
-npwg -l 12
-```
-
-Generate multiple passwords:
-```sh
-npwg -c 5
-```
-
-Generate a password using only uppercase and lowercase letters:
-```sh
-npwg -a upperletter,lowerletter
-```
-
-Generate a diceware passphrase:
-```sh
-npwg --use-words -l 6
-```
-
-Generate a diceware passphrase with a custom separator:
-```sh
-npwg --use-words --separator "-" -l 6
-```
-
-Generate a diceware passphrase with random separators:
-```sh
-npwg --use-words --separator random -l 6
-```
-
-Generate a pronounceable password:
-```sh
-npwg --pronounceable
-```
-
-Generate a password and display statistics:
-```sh
-npwg --stats
-```
-
-Generate a password and display the estimated strength:
-```sh 
-npwg --strength
-```
-
-Generate a password using the Diceware method. If no diceware wordlist is in ~/.npwg, it will be automatically downloaded from the EFF website:
+Specify length, count, and character sets:
 
 ```sh
-npwg -d
+npwg --length 20 --count 3 --allowed upperletter,lowerletter,digit
 ```
 
-Generate a password using the Diceware method with a custom number of words. The default number of words is 6. The wordlist will be downloaded if it is not found in ~/.npwg:
+Inspect entropy and statistics in one pass:
 
 ```sh
-npwg -d -w 8
+npwg --strength --stats
 ```
 
-Generate a diceware passphrase with a custom separator:
-```sh
-npwg --use-words --separator "-" -l 6
-```
+Copy freshly generated secrets to the clipboard:
 
-Generate a diceware passphrase with random separators:
-```sh
-npwg --use-words --separator random -l 6
-```
-
-Mutate an existing password:
-```sh
-npwg --mutate --mutation-type replace --mutation-strength 3
-```
-
-Generate a password and copy it to the clipboard:
 ```sh
 npwg --copy
+```
+
+#### Diceware Passphrases
+
+First run downloads and verifies the EFF wordlist automatically. Generate six-word phrases separated by spaces:
+
+```sh
+npwg --use-words --length 6
+```
+
+Customise separators or request random punctuation between words:
+
+```sh
+npwg --use-words --separator "-" --length 5
+npwg --use-words --separator random --length 7
+```
+
+#### Pronounceable and Pattern Modes
+
+Create pronounceable strings that alternate consonants and vowels:
+
+```sh
+npwg --pronounceable --length 10
+```
+
+Enforce structural patterns (L=letter, D=digit, S=symbol):
+
+```sh
+npwg --pattern LLDDS --length 16
+```
+
+#### Mutation Workflow
+
+Tweak existing passwords by applying deterministic mutations and optional lengthening:
+
+```sh
+npwg --mutate --mutation-type swap --mutation-strength 2 --lengthen 3
+```
+
+Use interactive mode for guided generation and mutation prompts:
+
+```sh
+npwg --interactive
+```
+
+### Configuration Profiles
+
+Create a `config.toml` in `~/.config/npwg/` (or `~/.npwg/` on systems without XDG directories) to store defaults and reusable profiles:
+
+```toml
+[defaults]
+length = 20
+allowed = "upperletter,lowerletter,digit"
+
+[profiles.work]
+count = 5
+use_words = true
+separator = "-"
+```
+
+Invoke a profile at runtime:
+
+```sh
+npwg --profile work
+```
+
+Provide a custom config path when needed:
+
+```sh
+npwg --config ./fixtures/npwg.toml --profile personal
 ```
 
 ## Contributing
 
 Contributions are welcome! If you find a bug or have a suggestion for improvement, please open an issue or submit a pull request.
+
+When contributing Rust code, include only the SPDX license header at the top of each `*.rs` file—avoid additional inline or block comments elsewhere.
 
 ## License
 

--- a/src/bin/test_pattern.rs
+++ b/src/bin/test_pattern.rs
@@ -5,22 +5,22 @@ fn main() {
     let pattern = "LDLS";
     let length = 10;
     let seed = None;
-    
+
     match generate_with_pattern(pattern, &available_chars, length, seed) {
         Ok(password) => {
             println!("Password generated: {}", password);
             println!("Password length: {}", password.len());
-            
+
             let all_valid = password.chars().all(|c| available_chars.contains(&c));
             println!("All characters valid: {}", all_valid);
-            
+
             let contains_digits = password.chars().any(|c| c.is_ascii_digit());
             println!("Contains digits: {} (should be false)", contains_digits);
-            
+
             assert!(all_valid, "Password should only contain valid characters");
             assert!(!contains_digits, "Password should not contain digits");
             println!("Tests passed!");
-        },
+        }
         Err(e) => println!("Error: {:?}", e),
     }
 }

--- a/src/bin/test_pattern_cases.rs
+++ b/src/bin/test_pattern_cases.rs
@@ -6,26 +6,37 @@ fn main() {
         ("LSLD", "abcdefg123", 10),
         ("LSLD", "abcdefg123!@#", 10),
     ];
-    
+
     println!("Testing generate_with_pattern with different scenarios:\n");
-    
+
     for (i, (pattern, chars_str, length)) in test_cases.iter().enumerate() {
         let available_chars: Vec<char> = chars_str.chars().collect();
         let seed = Some(42u64);
-        
+
         match generate_with_pattern(pattern, &available_chars, *length, seed) {
             Ok(password) => {
-                println!("Test case {}: Pattern '{}', Chars '{}'", i + 1, pattern, chars_str);
+                println!(
+                    "Test case {}: Pattern '{}', Chars '{}'",
+                    i + 1,
+                    pattern,
+                    chars_str
+                );
                 println!("  - Password: {}", password);
                 println!("  - Length: {}", password.len());
-                println!("  - Contains digits: {}", password.chars().any(|c| c.is_ascii_digit()));
-                println!("  - Contains special: {}", password.chars().any(|c| !c.is_ascii_alphanumeric()));
-                
+                println!(
+                    "  - Contains digits: {}",
+                    password.chars().any(|c| c.is_ascii_digit())
+                );
+                println!(
+                    "  - Contains special: {}",
+                    password.chars().any(|c| !c.is_ascii_alphanumeric())
+                );
+
                 let all_valid = password.chars().all(|c| available_chars.contains(&c));
                 println!("  - All chars valid: {}", all_valid);
                 assert!(all_valid, "Password should only contain valid characters");
                 println!("  - Test passed\n");
-            },
+            }
             Err(e) => println!("Error in test case {}: {:?}\n", i + 1, e),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -135,10 +135,14 @@ impl PasswordGeneratorConfig {
         }
 
         if !self.excluded_chars.is_empty()
-            && self.allowed_chars.iter().all(|c| self.excluded_chars.contains(c))
+            && self
+                .allowed_chars
+                .iter()
+                .all(|c| self.excluded_chars.contains(c))
         {
             return Err(PasswordGeneratorError::InvalidConfig(
-                "All allowed characters are excluded, resulting in an empty character set".to_string(),
+                "All allowed characters are excluded, resulting in an empty character set"
+                    .to_string(),
             ));
         }
 

--- a/src/diceware.rs
+++ b/src/diceware.rs
@@ -7,44 +7,108 @@
 use crate::error::PasswordGeneratorError;
 use crate::error::Result;
 use dirs::home_dir;
-use reqwest;
-use std::fs::{self, File};
-use std::io::Write;
-use std::path::PathBuf;
+use reqwest::Client;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 const DICEWARE_FILENAME: &str = "diceware_wordlist.txt";
 const DICEWARE_URL: &str = "https://www.eff.org/files/2016/07/18/eff_large_wordlist.txt";
+const DICEWARE_CHECKSUM_FILENAME: &str = "diceware_wordlist.sha256";
+const DICEWARE_TIMEOUT: Duration = Duration::from_secs(15);
+const EXPECTED_WORDLIST_LINES: usize = 7776;
 
 pub async fn get_wordlist() -> Result<Vec<String>> {
     let home = home_dir().ok_or_else(|| {
         std::io::Error::new(std::io::ErrorKind::NotFound, "Home directory not found")
     })?;
-    let wordlist_path = home.join(".npwg").join(DICEWARE_FILENAME);
+    let workdir = home.join(".npwg");
+    let wordlist_path = workdir.join(DICEWARE_FILENAME);
 
     if wordlist_path.exists() {
-        let wordlist = std::fs::read_to_string(&wordlist_path)?;
-        Ok(wordlist
-            .lines()
-            .filter_map(|line| line.split_once('\t'))
-            .map(|(_, word)| word.to_string())
-            .collect())
-    } else {
-        download_wordlist(&wordlist_path).await?;
-        Err(PasswordGeneratorError::WordlistDownloaded)
+        return load_wordlist(&wordlist_path);
     }
+
+    download_wordlist(&workdir, &wordlist_path).await?;
+    Err(PasswordGeneratorError::WordlistDownloaded)
 }
 
-async fn download_wordlist(wordlist_path: &PathBuf) -> Result<()> {
+fn load_wordlist(wordlist_path: &Path) -> Result<Vec<String>> {
+    let contents = fs::read_to_string(wordlist_path)?;
+    validate_wordlist(&contents, wordlist_path)?;
+    Ok(parse_wordlist(&contents))
+}
+
+async fn download_wordlist(workdir: &Path, wordlist_path: &Path) -> Result<()> {
     println!("Downloading wordlist from {}", DICEWARE_URL);
 
-    let response = reqwest::get(DICEWARE_URL).await?.text().await?;
-    fs::create_dir_all(wordlist_path.parent().ok_or_else(|| {
-        std::io::Error::new(std::io::ErrorKind::NotFound, "Parent directory not found")
-    })?)?;
+    fs::create_dir_all(workdir)?;
 
-    let mut file = File::create(wordlist_path)?;
-    file.write_all(response.as_bytes())?;
+    let client = Client::builder().timeout(DICEWARE_TIMEOUT).build()?;
+    let response = client.get(DICEWARE_URL).send().await?.error_for_status()?;
+    let bytes = response.bytes().await?;
+
+    if bytes.is_empty() {
+        return Err(PasswordGeneratorError::WordlistValidation(
+            "Downloaded wordlist was empty".to_string(),
+        ));
+    }
+
+    let contents = String::from_utf8(bytes.to_vec()).map_err(|err| {
+        PasswordGeneratorError::WordlistValidation(format!(
+            "Downloaded wordlist was not valid UTF-8: {}",
+            err
+        ))
+    })?;
+
+    fs::write(wordlist_path, contents.as_bytes())?;
+    validate_wordlist(&contents, wordlist_path)?;
 
     println!("Wordlist downloaded to {:?}", wordlist_path);
     Ok(())
+}
+
+fn parse_wordlist(contents: &str) -> Vec<String> {
+    contents
+        .lines()
+        .filter_map(|line| line.split_once('\t'))
+        .map(|(_, word)| word.to_string())
+        .collect()
+}
+
+fn validate_wordlist(contents: &str, wordlist_path: &Path) -> Result<()> {
+    let line_count = contents.lines().count();
+    if line_count != EXPECTED_WORDLIST_LINES {
+        return Err(PasswordGeneratorError::WordlistValidation(format!(
+            "Expected {} entries in {}, found {}",
+            EXPECTED_WORDLIST_LINES,
+            wordlist_path.display(),
+            line_count
+        )));
+    }
+
+    let checksum = format!("{:x}", Sha256::digest(contents.as_bytes()));
+    let checksum_path = checksum_path(wordlist_path);
+
+    if checksum_path.exists() {
+        let stored = fs::read_to_string(&checksum_path)?.trim().to_string();
+        if stored != checksum {
+            return Err(PasswordGeneratorError::WordlistValidation(format!(
+                "Checksum mismatch for {}. Delete the wordlist and rerun npwg to redownload.",
+                wordlist_path.display()
+            )));
+        }
+    } else {
+        fs::write(&checksum_path, &checksum)?;
+    }
+
+    Ok(())
+}
+
+fn checksum_path(wordlist_path: &Path) -> PathBuf {
+    wordlist_path
+        .parent()
+        .map(|parent| parent.join(DICEWARE_CHECKSUM_FILENAME))
+        .unwrap_or_else(|| PathBuf::from(DICEWARE_CHECKSUM_FILENAME))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,10 +17,14 @@ pub enum PasswordGeneratorError {
     Network(#[from] reqwest::Error),
     #[error("Wordlist downloaded, restart the program to use it.")]
     WordlistDownloaded,
+    #[error("Wordlist validation failed: {0}")]
+    WordlistValidation(String),
     #[error("Dialoguer error: {0}")]
     DialoguerError(DialoguerError),
     #[error("{0}")]
     ClipboardError(String),
+    #[error("Clipboard unavailable: {0}")]
+    ClipboardUnavailable(String),
 }
 
 impl From<DialoguerError> for PasswordGeneratorError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum PasswordGeneratorError {
     WordlistDownloaded,
     #[error("Wordlist validation failed: {0}")]
     WordlistValidation(String),
+    #[error("Configuration error: {0}")]
+    ConfigFile(String),
     #[error("Dialoguer error: {0}")]
     DialoguerError(DialoguerError),
     #[error("{0}")]

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -12,7 +12,10 @@ use crate::generator::{
     mutate_password, MutationType,
 };
 use crate::stats::show_stats;
-use crate::strength::{evaluate_password_strength, get_strength_bar, get_strength_feedback, get_improvement_suggestions};
+use crate::strength::{
+    evaluate_password_strength, get_improvement_suggestions, get_strength_bar,
+    get_strength_feedback,
+};
 use colored::Colorize;
 use console::Term;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
@@ -228,7 +231,13 @@ async fn mutate_interactive_password(term: &Term, theme: &ColorfulTheme) -> Resu
         .interact_on(term)?;
     let mutation_type = &mutation_types[mutation_type_index];
 
-    let mutated = mutate_password(&password, &config, lengthen, mutation_strength, Some(mutation_type));
+    let mutated = mutate_password(
+        &password,
+        &config,
+        lengthen,
+        mutation_strength,
+        Some(mutation_type),
+    );
 
     println!("\n{}", "Mutated Password:".bold().green());
     println!("Original: {}", password.yellow());
@@ -274,7 +283,7 @@ fn print_strength_meter(data: &[String]) {
             }),
             password.yellow()
         );
-        
+
         if strength < 0.6 {
             let suggestions = get_improvement_suggestions(password);
             if !suggestions.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod diceware;
 pub mod error;
 pub mod generator;
 pub mod interactive;
+pub mod policy;
+pub mod profile;
 pub mod stats;
 pub mod strength;
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@ pub mod config;
 pub mod diceware;
 pub mod error;
 pub mod generator;
+pub mod interactive;
 pub mod stats;
 pub mod strength;
-pub mod interactive;
 #[cfg(test)]
 pub mod tests;
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+// Project: npwg
+// File: src/policy.rs
+// Author: Volker Schwaberow <volker@schwaberow.de>
+
+use crate::config::{PasswordGeneratorConfig, Separator};
+use crate::error::Result;
+use crate::profile::apply_allowed_sets;
+use clap::ValueEnum;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum PolicyName {
+    #[clap(alias = "windows", alias = "ad")]
+    WindowsAd,
+    #[clap(alias = "pci")]
+    PciDss,
+    #[clap(alias = "nist")]
+    NistHigh,
+}
+
+pub struct PolicyDetails {
+    pub label: &'static str,
+    pub description: &'static str,
+    pub minimum_length: usize,
+    pub recommended_entropy_bits: f64,
+}
+
+pub fn apply_policy(
+    policy: PolicyName,
+    config: &mut PasswordGeneratorConfig,
+) -> Result<PolicyDetails> {
+    match policy {
+        PolicyName::WindowsAd => apply_windows_ad(config),
+        PolicyName::PciDss => apply_pci_dss(config),
+        PolicyName::NistHigh => apply_nist_high(config),
+    }
+}
+
+fn ensure_length(config: &mut PasswordGeneratorConfig, minimum: usize) {
+    if config.length < minimum {
+        config.length = minimum;
+    }
+}
+
+fn ensure_separator(config: &mut PasswordGeneratorConfig) {
+    if config.mode == crate::config::PasswordGeneratorMode::Diceware && config.separator.is_none() {
+        config.separator = Some(Separator::Fixed(' '));
+    }
+}
+
+fn apply_windows_ad(config: &mut PasswordGeneratorConfig) -> Result<PolicyDetails> {
+    ensure_length(config, 14);
+    apply_allowed_sets(config, "upperletter,lowerletter,digit,symbol2")?;
+    config.set_avoid_repeating(false);
+    config.pattern = None;
+    config.pronounceable = false;
+    config.mode = crate::config::PasswordGeneratorMode::Password;
+    ensure_separator(config);
+    Ok(PolicyDetails {
+        label: "Windows Active Directory",
+        description: "Requires 14+ characters including upper, lower, digits, and symbols.",
+        minimum_length: 14,
+        recommended_entropy_bits: 84.0,
+    })
+}
+
+fn apply_pci_dss(config: &mut PasswordGeneratorConfig) -> Result<PolicyDetails> {
+    ensure_length(config, 12);
+    apply_allowed_sets(config, "upperletter,lowerletter,digit,symbol2")?;
+    config.set_avoid_repeating(false);
+    config.mode = crate::config::PasswordGeneratorMode::Password;
+    ensure_separator(config);
+    Ok(PolicyDetails {
+        label: "PCI DSS",
+        description: "Minimum 12 characters with mixed character classes per PCI DSS 4.0.",
+        minimum_length: 12,
+        recommended_entropy_bits: 72.0,
+    })
+}
+
+fn apply_nist_high(config: &mut PasswordGeneratorConfig) -> Result<PolicyDetails> {
+    ensure_length(config, 16);
+    apply_allowed_sets(config, "upperletter,lowerletter,digit,symbol2")?;
+    config.set_avoid_repeating(true);
+    config.mode = crate::config::PasswordGeneratorMode::Password;
+    ensure_separator(config);
+    Ok(PolicyDetails {
+        label: "NIST SP 800-63B High",
+        description: "High assurance memorized secret guidance (16+ characters)",
+        minimum_length: 16,
+        recommended_entropy_bits: 96.0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PasswordGeneratorConfig;
+
+    #[test]
+    fn windows_policy_enforces_length_and_sets() {
+        let mut config = PasswordGeneratorConfig::new();
+        config.length = 8;
+        let details = apply_policy(PolicyName::WindowsAd, &mut config).unwrap();
+        assert_eq!(details.minimum_length, 14);
+        assert!(config.length >= 14);
+        assert!(config.allowed_chars.iter().any(|c| c.is_ascii_uppercase()));
+        assert!(config
+            .allowed_chars
+            .iter()
+            .any(|c| !c.is_ascii_alphanumeric()));
+    }
+
+    #[test]
+    fn policy_can_raise_entropy_expectations() {
+        let mut config = PasswordGeneratorConfig::new();
+        let details = apply_policy(PolicyName::NistHigh, &mut config).unwrap();
+        assert_eq!(details.recommended_entropy_bits as u32, 96);
+        assert!(config.length >= 16);
+    }
+}

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+// Project: npwg
+// File: src/profile.rs
+// Author: Volker Schwaberow <volker@schwaberow.de>
+
+use crate::config::{PasswordGeneratorConfig, PasswordGeneratorMode, Separator, DEFINE};
+use crate::error::{PasswordGeneratorError, Result};
+use dirs::{config_dir, home_dir};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Default, Deserialize)]
+pub struct UserProfiles {
+    #[serde(default)]
+    defaults: Option<ProfileDefinition>,
+    #[serde(default)]
+    profiles: HashMap<String, ProfileDefinition>,
+}
+
+#[derive(Clone, Default, Deserialize)]
+pub struct ProfileDefinition {
+    length: Option<usize>,
+    count: Option<usize>,
+    allowed: Option<String>,
+    avoid_repeating: Option<bool>,
+    use_words: Option<bool>,
+    separator: Option<String>,
+    pronounceable: Option<bool>,
+    pattern: Option<String>,
+    seed: Option<u64>,
+}
+
+impl UserProfiles {
+    pub fn defaults(&self) -> Option<&ProfileDefinition> {
+        self.defaults.as_ref()
+    }
+
+    pub fn get(&self, name: &str) -> Option<&ProfileDefinition> {
+        self.profiles.get(name)
+    }
+}
+
+pub fn load_user_profiles(path_override: Option<&String>) -> Result<UserProfiles> {
+    let path = determine_config_path(path_override);
+    let Some(path) = path else {
+        return Ok(UserProfiles::default());
+    };
+    if !path.exists() {
+        return Ok(UserProfiles::default());
+    }
+    let contents = fs::read_to_string(&path).map_err(|error| {
+        PasswordGeneratorError::ConfigFile(format!("Failed to read {}: {}", path.display(), error))
+    })?;
+    let profiles: UserProfiles = toml::from_str(&contents).map_err(|error| {
+        PasswordGeneratorError::ConfigFile(format!(
+            "Invalid config in {}: {}",
+            path.display(),
+            error
+        ))
+    })?;
+    Ok(profiles)
+}
+
+pub fn apply_profile(
+    profile: &ProfileDefinition,
+    config: &mut PasswordGeneratorConfig,
+) -> Result<()> {
+    if let Some(length) = profile.length {
+        config.length = length;
+    }
+    if let Some(count) = profile.count {
+        config.num_passwords = count;
+    }
+    if let Some(avoid) = profile.avoid_repeating {
+        config.set_avoid_repeating(avoid);
+    }
+    if let Some(seed) = profile.seed {
+        config.seed = Some(seed);
+    }
+    if let Some(pronounceable) = profile.pronounceable {
+        config.pronounceable = pronounceable;
+    }
+    if let Some(pattern) = profile.pattern.as_ref() {
+        config.pattern = Some(pattern.clone());
+    }
+    if let Some(allowed) = profile.allowed.as_ref() {
+        apply_allowed_sets(config, allowed)?;
+    }
+    if let Some(use_words) = profile.use_words {
+        config.set_use_words(use_words);
+        if use_words {
+            if config.separator.is_none() {
+                config.separator = Some(Separator::Fixed(' '));
+            }
+        } else {
+            config.separator = None;
+        }
+    }
+    if let Some(value) = profile.separator.as_ref() {
+        config.separator = Some(parse_separator(value)?);
+    }
+    Ok(())
+}
+
+fn determine_config_path(path_override: Option<&String>) -> Option<PathBuf> {
+    if let Some(path) = path_override {
+        return Some(PathBuf::from(path));
+    }
+    if let Some(dir) = config_dir() {
+        return Some(dir.join("npwg").join("config.toml"));
+    }
+    home_dir().map(|home| home.join(".npwg").join("config.toml"))
+}
+
+pub fn apply_allowed_sets(config: &mut PasswordGeneratorConfig, allowed: &str) -> Result<()> {
+    config.clear_allowed_chars();
+    for charset in allowed
+        .split(',')
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        if !DEFINE.iter().any(|&(name, _)| name == charset) {
+            return Err(PasswordGeneratorError::ConfigFile(format!(
+                "Unknown characterset '{}' in config",
+                charset
+            )));
+        }
+        config.add_allowed_chars(charset);
+    }
+    if config.allowed_chars.is_empty() {
+        return Err(PasswordGeneratorError::ConfigFile(
+            "Allowed character set resolved to empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn parse_separator(value: &str) -> Result<Separator> {
+    if value == "random" {
+        let chars: Vec<char> = ('a'..='z').chain('0'..='9').collect();
+        return Ok(Separator::Random(chars));
+    }
+    if value.chars().count() == 1 {
+        let separator = value.chars().next().unwrap();
+        return Ok(Separator::Fixed(separator));
+    }
+    Err(PasswordGeneratorError::ConfigFile(
+        "Separator must be a single character or 'random'".to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_profile_overrides_defaults() {
+        let mut config = PasswordGeneratorConfig::new();
+        let profile = ProfileDefinition {
+            length: Some(24),
+            count: Some(3),
+            allowed: Some("upperletter,lowerletter".to_string()),
+            avoid_repeating: Some(true),
+            use_words: Some(true),
+            separator: Some("-".to_string()),
+            pronounceable: Some(false),
+            pattern: Some("LLDDS".to_string()),
+            seed: Some(99),
+        };
+        apply_profile(&profile, &mut config).unwrap();
+        assert_eq!(config.length, 24);
+        assert_eq!(config.num_passwords, 3);
+        assert!(config.avoid_repetition);
+        assert_eq!(config.seed, Some(99));
+        assert_eq!(config.pattern.as_deref(), Some("LLDDS"));
+        assert!(matches!(config.mode, PasswordGeneratorMode::Diceware));
+        match config.separator.as_ref().unwrap() {
+            Separator::Fixed(value) => assert_eq!(*value, '-'),
+            _ => panic!(),
+        }
+        assert_eq!(config.allowed_chars.len(), 52);
+    }
+
+    #[test]
+    fn parse_separator_errors_for_invalid_values() {
+        let error = parse_separator("too-long").err().unwrap();
+        match error {
+            PasswordGeneratorError::ConfigFile(message) => assert!(message.contains("Separator")),
+            _ => panic!(),
+        }
+    }
+}

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -3,7 +3,7 @@
 // File: src/profile.rs
 // Author: Volker Schwaberow <volker@schwaberow.de>
 
-use crate::config::{PasswordGeneratorConfig, PasswordGeneratorMode, Separator, DEFINE};
+use crate::config::{PasswordGeneratorConfig, Separator, DEFINE};
 use crate::error::{PasswordGeneratorError, Result};
 use dirs::{config_dir, home_dir};
 use serde::Deserialize;
@@ -154,6 +154,7 @@ pub fn parse_separator(value: &str) -> Result<Separator> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::PasswordGeneratorMode;
 
     #[test]
     fn apply_profile_overrides_defaults() {

--- a/src/strength.rs
+++ b/src/strength.rs
@@ -8,13 +8,13 @@ use std::collections::{HashMap, HashSet};
 use std::f64;
 
 /// Evaluates password strength using a comprehensive multi-factor analysis approach.
-/// 
+///
 /// This implementation is based on multiple academic research papers on password security:
 /// - Shannon entropy calculation for character-set complexity
 /// - NIST SP 800-63B guideline compliance
 /// - Pattern-based vulnerability detection (similar to zxcvbn)
 /// - Markov model principles for sequential probability
-/// 
+///
 /// Returns a normalized score between 0.0 and 1.0 where:
 /// - 0.0-0.3: Very weak to weak
 /// - 0.3-0.6: Moderate
@@ -27,15 +27,14 @@ pub fn evaluate_password_strength(password: &str) -> f64 {
     let pattern_penalty = detect_patterns(password);
     let diversity_score = calculate_diversity(password);
     let nist_compliance_score = check_nist_compliance(password);
-    
+
     // Weighted combination of metrics (weights determined by empirical testing)
-    let weighted_score = (
-        (entropy_score * 0.45) +
-        (diversity_score * 0.25) +
-        (nist_compliance_score * 0.15) +
-        (pattern_penalty * 0.15)
-    ).min(1.0);
-    
+    let weighted_score = ((entropy_score * 0.45)
+        + (diversity_score * 0.25)
+        + (nist_compliance_score * 0.15)
+        + (pattern_penalty * 0.15))
+        .min(1.0);
+
     weighted_score
 }
 
@@ -81,37 +80,37 @@ pub fn calculate_entropy(password: &str) -> f64 {
 fn detect_patterns(password: &str) -> f64 {
     let mut score = 1.0;
     let lowercase = password.to_lowercase();
-    
+
     // Detect sequential characters (abc, 123, etc.)
     if has_sequential_chars(password) {
         score *= 0.9;
     }
-    
+
     // Detect repeated characters (aaa, 111, etc.)
     if has_repeated_chars(password) {
         score *= 0.85;
     }
-    
+
     // Check for keyboard patterns (qwerty, asdfgh, etc.)
     if has_keyboard_pattern(password) {
         score *= 0.8;
     }
-    
+
     // Check for common words, names, or dates
     if contains_common_word(&lowercase) {
         score *= 0.7;
     }
-    
+
     // Check for leetspeak substitutions (p@ssw0rd)
     if contains_leetspeak(&lowercase) {
         score *= 0.9;
     }
-    
+
     // Check for date patterns (MMDDYYYY, DDMMYYYY, etc.)
     if contains_date_pattern(password) {
         score *= 0.85;
     }
-    
+
     score
 }
 
@@ -119,14 +118,14 @@ fn detect_patterns(password: &str) -> f64 {
 fn calculate_diversity(password: &str) -> f64 {
     let mut char_types = HashSet::new();
     let total_chars = password.len() as f64;
-    
+
     // Count frequencies of different character types
     let mut lowercase_count = 0;
     let mut uppercase_count = 0;
     let mut digit_count = 0;
     let mut symbol_count = 0;
     let mut other_count = 0;
-    
+
     for c in password.chars() {
         if c.is_ascii_lowercase() {
             char_types.insert("lowercase");
@@ -145,10 +144,10 @@ fn calculate_diversity(password: &str) -> f64 {
             other_count += 1;
         }
     }
-    
+
     // Calculate character type diversity (0.0 to 1.0)
     let type_diversity = (char_types.len() as f64 / 5.0).min(1.0);
-    
+
     // Calculate distribution uniformity (higher is better)
     let mut distribution_score = 1.0;
     if total_chars > 0.0 {
@@ -157,9 +156,9 @@ fn calculate_diversity(password: &str) -> f64 {
             uppercase_count as f64 / total_chars,
             digit_count as f64 / total_chars,
             symbol_count as f64 / total_chars,
-            other_count as f64 / total_chars
+            other_count as f64 / total_chars,
         ];
-        
+
         for count in type_counts.iter() {
             if *count > 0.8 {
                 // Penalize if one type dominates (>80%)
@@ -168,7 +167,7 @@ fn calculate_diversity(password: &str) -> f64 {
             }
         }
     }
-    
+
     // Weight type diversity more than distribution
     (type_diversity * 0.8 + distribution_score * 0.2).min(1.0)
 }
@@ -176,28 +175,28 @@ fn calculate_diversity(password: &str) -> f64 {
 /// Checks password against NIST SP 800-63B guidelines
 fn check_nist_compliance(password: &str) -> f64 {
     let mut score = 1.0;
-    
+
     // NIST guideline: Minimum 8 characters
     if password.len() < 8 {
         score *= 0.5;
     }
-    
+
     // Check for repetition of the same character
     if password.len() > 1 {
         let chars: Vec<char> = password.chars().collect();
         for i in 1..chars.len() {
-            if chars[i] == chars[i-1] {
+            if chars[i] == chars[i - 1] {
                 let repetition_penalty = 0.98;
                 score *= repetition_penalty; // Small penalty for each repetition
             }
         }
     }
-    
+
     // Check if password appears in common password lists (simplified check)
     if contains_common_password(password) {
         score *= 0.3; // Significant penalty for common passwords
     }
-    
+
     score
 }
 
@@ -249,12 +248,16 @@ pub fn get_theoretical_char_set_size(password: &str) -> usize {
     }
 
     if char_sets.contains("other") {
-        let unique_other_chars_count = password.chars().filter(|c| {
-            !c.is_ascii_lowercase() &&
-            !c.is_ascii_uppercase() &&
-            !c.is_ascii_digit() &&
-            !PUNCTUATION_CHAR_SET.contains(*c)
-        }).collect::<HashSet<char>>().len();
+        let unique_other_chars_count = password
+            .chars()
+            .filter(|c| {
+                !c.is_ascii_lowercase()
+                    && !c.is_ascii_uppercase()
+                    && !c.is_ascii_digit()
+                    && !PUNCTUATION_CHAR_SET.contains(*c)
+            })
+            .collect::<HashSet<char>>()
+            .len();
 
         if !has_known_ascii_type {
             total_size = unique_other_chars_count;
@@ -275,12 +278,14 @@ fn has_sequential_chars(password: &str) -> bool {
     // ASCII sequences
     let chars: Vec<char> = password.chars().collect();
     for window in chars.windows(3) {
-        if (window[0] as u32 + 1 == window[1] as u32 && window[1] as u32 + 1 == window[2] as u32) ||
-           (window[0] as u32 - 1 == window[1] as u32 && window[1] as u32 - 1 == window[2] as u32) {
+        if (window[0] as u32 + 1 == window[1] as u32 && window[1] as u32 + 1 == window[2] as u32)
+            || (window[0] as u32 - 1 == window[1] as u32
+                && window[1] as u32 - 1 == window[2] as u32)
+        {
             return true;
         }
     }
-    
+
     // Alphabetical sequences like "abc", "xyz"
     let alphabet = "abcdefghijklmnopqrstuvwxyz";
     for i in 0..alphabet.len() - 2 {
@@ -288,7 +293,7 @@ fn has_sequential_chars(password: &str) -> bool {
             return true;
         }
     }
-    
+
     // Number sequences
     let numbers = "0123456789";
     for i in 0..numbers.len() - 2 {
@@ -296,7 +301,7 @@ fn has_sequential_chars(password: &str) -> bool {
             return true;
         }
     }
-    
+
     false
 }
 
@@ -314,11 +319,10 @@ fn has_repeated_chars(password: &str) -> bool {
 /// Detects keyboard patterns in the password
 fn has_keyboard_pattern(password: &str) -> bool {
     let keyboard_patterns = [
-        "qwerty", "asdfgh", "zxcvbn", "qwertz", "azerty",
-        "1qaz", "2wsx", "3edc", "4rfv", "5tgb", "6yhn",
-        "7ujm", "8ik,", "9ol.", "0p;/", "-['", "=]\\",
+        "qwerty", "asdfgh", "zxcvbn", "qwertz", "azerty", "1qaz", "2wsx", "3edc", "4rfv", "5tgb",
+        "6yhn", "7ujm", "8ik,", "9ol.", "0p;/", "-['", "=]\\",
     ];
-    
+
     let lowercase = password.to_lowercase();
     for pattern in keyboard_patterns.iter() {
         if lowercase.contains(pattern) {
@@ -331,14 +335,12 @@ fn has_keyboard_pattern(password: &str) -> bool {
 /// Checks if the password contains common words or names
 fn contains_common_word(password: &str) -> bool {
     let common_words = [
-        "password", "123456", "qwerty", "admin", "welcome",
-        "letmein", "monkey", "dragon", "baseball", "football",
-        "master", "hello", "login", "abc123", "sunshine",
-        "princess", "starwars", "access", "shadow", "michael",
-        "batman", "superman", "love", "summer", "winter", 
-        "spring", "autumn", "secret",
+        "password", "123456", "qwerty", "admin", "welcome", "letmein", "monkey", "dragon",
+        "baseball", "football", "master", "hello", "login", "abc123", "sunshine", "princess",
+        "starwars", "access", "shadow", "michael", "batman", "superman", "love", "summer",
+        "winter", "spring", "autumn", "secret",
     ];
-    
+
     for word in common_words.iter() {
         if password.contains(word) {
             return true;
@@ -350,16 +352,15 @@ fn contains_common_word(password: &str) -> bool {
 /// Detects leetspeak substitutions in the password
 fn contains_leetspeak(password: &str) -> bool {
     let leetspeak_words = [
-        "p@ssw0rd", "p455w0rd", "passw0rd", "pa55word", 
-        "l3tm31n", "adm1n",
+        "p@ssw0rd", "p455w0rd", "passw0rd", "pa55word", "l3tm31n", "adm1n",
     ];
-    
+
     for word in leetspeak_words.iter() {
         if password.contains(word) {
             return true;
         }
     }
-    
+
     // Check for patterns of leetspeak substitutions
     let mut contains_substitution = false;
     if password.contains('0') && password.contains('o') {
@@ -373,7 +374,7 @@ fn contains_leetspeak(password: &str) -> bool {
     } else if password.contains('5') && password.contains('s') {
         contains_substitution = true;
     }
-    
+
     contains_substitution
 }
 
@@ -381,59 +382,133 @@ fn contains_leetspeak(password: &str) -> bool {
 fn contains_date_pattern(password: &str) -> bool {
     // Check for common date formats: MMDDYYYY, DDMMYYYY, MMDDYY, DDMMYY, etc.
     let digits: String = password.chars().filter(|c| c.is_ascii_digit()).collect();
-    
+
     if digits.len() >= 6 {
         if digits.len() == 6 || digits.len() == 8 {
             // Simple validation for plausible date components
             let possible_month = &digits[0..2];
             let possible_day = &digits[2..4];
-            
+
             let month = possible_month.parse::<u32>().unwrap_or(0);
             let day = possible_day.parse::<u32>().unwrap_or(0);
-            
+
             if (month >= 1 && month <= 12) && (day >= 1 && day <= 31) {
                 return true;
             }
-            
+
             // Check alternate format (day/month instead of month/day)
             let alt_month = possible_day;
             let alt_day = possible_month;
-            
+
             let alt_month_val = alt_month.parse::<u32>().unwrap_or(0);
             let alt_day_val = alt_day.parse::<u32>().unwrap_or(0);
-            
-            if (alt_month_val >= 1 && alt_month_val <= 12) && (alt_day_val >= 1 && alt_day_val <= 31) {
+
+            if (alt_month_val >= 1 && alt_month_val <= 12)
+                && (alt_day_val >= 1 && alt_day_val <= 31)
+            {
                 return true;
             }
         }
     }
-    
+
     false
 }
 
 /// Checks if the password appears in the list of commonly used passwords
 fn contains_common_password(password: &str) -> bool {
     let common_passwords = [
-        "123456", "password", "12345678", "qwerty", "123456789",
-        "12345", "1234", "111111", "1234567", "dragon",
-        "123123", "baseball", "abc123", "football", "monkey",
-        "letmein", "shadow", "master", "666666", "qwertyuiop",
-        "123321", "mustang", "1234567890", "michael", "654321",
-        "superman", "1qaz2wsx", "7777777", "121212", "000000",
-        "qazwsx", "123qwe", "killer", "trustno1", "jordan",
-        "jennifer", "hunter", "buster", "soccer", "harley",
-        "batman", "andrew", "tigger", "sunshine", "iloveyou",
-        "2000", "charlie", "robert", "thomas", "hockey",
-        "ranger", "daniel", "starwars", "klaster", "112233",
-        "george", "computer", "michelle", "jessica", "pepper",
-        "1111", "zxcvbn", "555555", "11111111", "131313",
-        "freedom", "777777", "pass", "maggie", "159753",
-        "aaaaaa", "ginger", "princess", "joshua", "cheese",
-        "amanda", "summer", "love", "ashley", "nicole",
-        "chelsea", "biteme", "matthew", "access", "yankees",
-        "987654321", "dallas", "austin", "thunder", "taylor",
+        "123456",
+        "password",
+        "12345678",
+        "qwerty",
+        "123456789",
+        "12345",
+        "1234",
+        "111111",
+        "1234567",
+        "dragon",
+        "123123",
+        "baseball",
+        "abc123",
+        "football",
+        "monkey",
+        "letmein",
+        "shadow",
+        "master",
+        "666666",
+        "qwertyuiop",
+        "123321",
+        "mustang",
+        "1234567890",
+        "michael",
+        "654321",
+        "superman",
+        "1qaz2wsx",
+        "7777777",
+        "121212",
+        "000000",
+        "qazwsx",
+        "123qwe",
+        "killer",
+        "trustno1",
+        "jordan",
+        "jennifer",
+        "hunter",
+        "buster",
+        "soccer",
+        "harley",
+        "batman",
+        "andrew",
+        "tigger",
+        "sunshine",
+        "iloveyou",
+        "2000",
+        "charlie",
+        "robert",
+        "thomas",
+        "hockey",
+        "ranger",
+        "daniel",
+        "starwars",
+        "klaster",
+        "112233",
+        "george",
+        "computer",
+        "michelle",
+        "jessica",
+        "pepper",
+        "1111",
+        "zxcvbn",
+        "555555",
+        "11111111",
+        "131313",
+        "freedom",
+        "777777",
+        "pass",
+        "maggie",
+        "159753",
+        "aaaaaa",
+        "ginger",
+        "princess",
+        "joshua",
+        "cheese",
+        "amanda",
+        "summer",
+        "love",
+        "ashley",
+        "nicole",
+        "chelsea",
+        "biteme",
+        "matthew",
+        "access",
+        "yankees",
+        "987654321",
+        "dallas",
+        "austin",
+        "thunder",
+        "taylor",
     ];
-    
+
     common_passwords.contains(&password.to_lowercase().as_str())
 }
 
@@ -451,16 +526,16 @@ pub fn get_strength_feedback(score: f64) -> String {
 /// Gets specific improvement suggestions based on password analysis
 pub fn get_improvement_suggestions(password: &str) -> Vec<String> {
     let mut suggestions = Vec::new();
-    
+
     if password.len() < 12 {
         suggestions.push("Increase password length to at least 12 characters".to_string());
     }
-    
+
     let mut has_lowercase = false;
     let mut has_uppercase = false;
     let mut has_digit = false;
     let mut has_symbol = false;
-    
+
     for c in password.chars() {
         if c.is_ascii_lowercase() {
             has_lowercase = true;
@@ -472,7 +547,7 @@ pub fn get_improvement_suggestions(password: &str) -> Vec<String> {
             has_symbol = true;
         }
     }
-    
+
     if !has_lowercase {
         suggestions.push("Add lowercase letters".to_string());
     }
@@ -485,27 +560,27 @@ pub fn get_improvement_suggestions(password: &str) -> Vec<String> {
     if !has_symbol {
         suggestions.push("Add special characters".to_string());
     }
-    
+
     if has_sequential_chars(password) {
         suggestions.push("Avoid sequential characters (abc, 123)".to_string());
     }
-    
+
     if has_repeated_chars(password) {
         suggestions.push("Avoid repeated characters (aaa, 111)".to_string());
     }
-    
+
     if has_keyboard_pattern(password) {
         suggestions.push("Avoid keyboard patterns (qwerty, asdfgh)".to_string());
     }
-    
+
     if contains_common_word(&password.to_lowercase()) {
         suggestions.push("Avoid common words or phrases".to_string());
     }
-    
+
     if contains_date_pattern(password) {
         suggestions.push("Avoid using dates in your password".to_string());
     }
-    
+
     suggestions
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,15 +7,18 @@
 #[cfg(test)]
 mod tests {
     use crate::config::PasswordGeneratorConfig;
-    use crate::generator::{generate_diceware_passphrase, generate_password};
-    use crate::stats::show_stats;
     use crate::error::PasswordGeneratorError;
-    
+    use crate::generator::{generate_diceware_passphrase, generate_password};
+    use crate::generator::{generate_pronounceable_password, mutate_password, MutationType};
+    use crate::stats::show_stats;
+
     async fn generate_diceware_passphrase_test(wordlist: &[String], num_words: usize) -> String {
         let mut config = PasswordGeneratorConfig::new();
         config.length = num_words;
         config.mode = crate::config::PasswordGeneratorMode::Diceware;
-        let results = generate_diceware_passphrase(wordlist, &config).await.unwrap();
+        let results = generate_diceware_passphrase(wordlist, &config)
+            .await
+            .unwrap();
         results.into_iter().next().unwrap_or_default()
     }
 
@@ -49,6 +52,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_generate_pronounceable_password_pattern() {
+        let mut config = PasswordGeneratorConfig::new();
+        config.pronounceable = true;
+        config.length = 8;
+        let password = generate_pronounceable_password(&config).await.unwrap();
+        assert_eq!(password.len(), 8);
+        let consonants = "bcdfghjklmnpqrstvwxyz";
+        let vowels = "aeiou";
+        for (idx, ch) in password.chars().enumerate() {
+            if idx % 2 == 0 {
+                assert!(consonants.contains(ch));
+            } else {
+                assert!(vowels.contains(ch));
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn test_generate_diceware_passphrase() {
         let wordlist = vec![
             "apple".to_string(),
@@ -59,10 +80,10 @@ mod tests {
         ];
 
         let passphrase = generate_diceware_passphrase_test(&wordlist, 4).await;
-        
+
         // Check if we have received a passphrase with words
         assert!(!passphrase.is_empty(), "Passphrase should not be empty");
-        
+
         // We need to check if the words from our original list are present
         // rather than counting words in the output, since separators might vary
         for word in &wordlist {
@@ -71,7 +92,7 @@ mod tests {
                 return;
             }
         }
-        
+
         panic!("Passphrase does not contain any words from the wordlist");
     }
 
@@ -79,27 +100,62 @@ mod tests {
     fn test_show_stats_single_password() {
         let passwords = vec!["password123".to_string()];
         let stats = show_stats(&passwords);
-        assert_eq!(stats.variance, 0.0, "Variance should be 0.0 for a single password");
-        assert_eq!(stats.skewness, 0.0, "Skewness should be 0.0 for a single password");
-        assert_eq!(stats.kurtosis, -3.0, "Kurtosis should be -3.0 for a single password (excess kurtosis)");
+        assert_eq!(
+            stats.variance, 0.0,
+            "Variance should be 0.0 for a single password"
+        );
+        assert_eq!(
+            stats.skewness, 0.0,
+            "Skewness should be 0.0 for a single password"
+        );
+        assert_eq!(
+            stats.kurtosis, -3.0,
+            "Kurtosis should be -3.0 for a single password (excess kurtosis)"
+        );
     }
 
     #[test]
     fn test_show_stats_identical_passwords() {
-        let passwords = vec!["password123".to_string(), "password123".to_string(), "password123".to_string()];
+        let passwords = vec![
+            "password123".to_string(),
+            "password123".to_string(),
+            "password123".to_string(),
+        ];
         let stats = show_stats(&passwords);
-        assert!(stats.variance.abs() < 1e-10, "Variance should be approximately 0.0 for identical passwords");
-        assert!(stats.skewness.is_finite(), "Skewness should be finite for identical passwords");
-        assert_eq!(stats.kurtosis, -3.0, "Kurtosis should be -3.0 for identical passwords (excess kurtosis)");
+        assert!(
+            stats.variance.abs() < 1e-10,
+            "Variance should be approximately 0.0 for identical passwords"
+        );
+        assert!(
+            stats.skewness.is_finite(),
+            "Skewness should be finite for identical passwords"
+        );
+        assert_eq!(
+            stats.kurtosis, -3.0,
+            "Kurtosis should be -3.0 for identical passwords (excess kurtosis)"
+        );
     }
 
     #[test]
     fn test_show_stats_different_passwords() {
-        let passwords = vec!["password123".to_string(), "anotherOne".to_string(), "testPwd!".to_string()];
+        let passwords = vec![
+            "password123".to_string(),
+            "anotherOne".to_string(),
+            "testPwd!".to_string(),
+        ];
         let stats = show_stats(&passwords);
-        assert!(stats.variance > 0.0, "Variance should be greater than 0 for different passwords");
-        assert!(stats.skewness.is_finite(), "Skewness should be a finite number");
-        assert!(stats.kurtosis.is_finite(), "Kurtosis should be a finite number");
+        assert!(
+            stats.variance > 0.0,
+            "Variance should be greater than 0 for different passwords"
+        );
+        assert!(
+            stats.skewness.is_finite(),
+            "Skewness should be a finite number"
+        );
+        assert!(
+            stats.kurtosis.is_finite(),
+            "Kurtosis should be a finite number"
+        );
     }
 
     #[test]
@@ -107,19 +163,28 @@ mod tests {
         let passwords: Vec<String> = Vec::new();
         let stats = show_stats(&passwords);
         assert_eq!(stats.mean, 0.0, "Mean should be 0.0 for an empty list");
-        assert_eq!(stats.variance, 0.0, "Variance should be 0.0 for an empty list");
-        assert_eq!(stats.skewness, 0.0, "Skewness should be 0.0 for an empty list");
-        assert_eq!(stats.kurtosis, 0.0, "Kurtosis should be 0.0 for an empty list");
+        assert_eq!(
+            stats.variance, 0.0,
+            "Variance should be 0.0 for an empty list"
+        );
+        assert_eq!(
+            stats.skewness, 0.0,
+            "Skewness should be 0.0 for an empty list"
+        );
+        assert_eq!(
+            stats.kurtosis, 0.0,
+            "Kurtosis should be 0.0 for an empty list"
+        );
     }
 
     #[tokio::test]
     async fn test_generate_password_with_empty_available_chars() {
         let mut config = PasswordGeneratorConfig::new();
         config.clear_allowed_chars();
-        
+
         let result = generate_password(&config).await;
         assert!(result.is_err(), "Expected error for empty available_chars");
-        
+
         if let Err(err) = result {
             match err {
                 PasswordGeneratorError::InvalidConfig(_) => {
@@ -135,11 +200,14 @@ mod tests {
     #[tokio::test]
     async fn test_generate_password_with_all_chars_excluded() {
         let mut config = PasswordGeneratorConfig::new();
-        config.set_allowed_chars("digit");        
+        config.set_allowed_chars("digit");
         config.excluded_chars.extend("0123456789".chars());
         let result = generate_password(&config).await;
-        assert!(result.is_err(), "Expected error when all chars are excluded");
-        
+        assert!(
+            result.is_err(),
+            "Expected error when all chars are excluded"
+        );
+
         if let Err(err) = result {
             match err {
                 PasswordGeneratorError::InvalidConfig(_) => {
@@ -150,6 +218,29 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_mutate_password_replace_changes_character() {
+        let mut config = PasswordGeneratorConfig::new();
+        config.set_allowed_chars("lowerletter");
+        config.seed = Some(42);
+        let forced = MutationType::Replace;
+        let original = "password";
+        let mutated = mutate_password(original, &config, 0, 1, Some(&forced));
+        assert_eq!(mutated.len(), original.len());
+        assert_ne!(mutated, original);
+    }
+
+    #[test]
+    fn test_mutate_password_lengthen_appends_characters() {
+        let mut config = PasswordGeneratorConfig::new();
+        config.set_allowed_chars("digit");
+        config.seed = Some(7);
+        let original = "1234";
+        let mutated = mutate_password(original, &config, 3, 0, None);
+        assert_eq!(mutated.len(), original.len() + 3);
+        assert!(mutated.starts_with(original));
     }
 }
 
@@ -180,7 +271,7 @@ mod strength_tests {
 
     #[test]
     fn test_gcss_punctuation_only() {
-        assert_eq!(get_theoretical_char_set_size("!@#"), 32); 
+        assert_eq!(get_theoretical_char_set_size("!@#"), 32);
         assert_eq!(get_theoretical_char_set_size("!!!"), 32);
     }
 
@@ -213,25 +304,28 @@ mod strength_tests {
     fn test_gcss_only_other_repeated() {
         assert_eq!(get_theoretical_char_set_size("€€€"), 1);
     }
-    
+
     #[test]
     fn test_gcss_known_and_other_unique() {
-        assert_eq!(get_theoretical_char_set_size("abcαβ"), 26 + 2); 
+        assert_eq!(get_theoretical_char_set_size("abcαβ"), 26 + 2);
     }
 
     #[test]
     fn test_gcss_known_and_other_mixed() {
-        assert_eq!(get_theoretical_char_set_size("aA1!€"), 26 + 26 + 10 + 32 + 1);
+        assert_eq!(
+            get_theoretical_char_set_size("aA1!€"),
+            26 + 26 + 10 + 32 + 1
+        );
     }
-    
+
     #[test]
-    fn test_gcss_space_only() { 
+    fn test_gcss_space_only() {
         assert_eq!(get_theoretical_char_set_size(" "), 1);
         assert_eq!(get_theoretical_char_set_size("   "), 1);
     }
 
     #[test]
-    fn test_gcss_space_and_letter() { 
+    fn test_gcss_space_and_letter() {
         assert_eq!(get_theoretical_char_set_size("a b"), 26 + 1);
     }
 
@@ -243,25 +337,41 @@ mod strength_tests {
     #[test]
     fn test_calc_entropy_single_char_type_all_same() {
         let score = calculate_entropy("aaaaa");
-        assert!((score - 0.18).abs() < 0.001, "Expected approx 0.18, got {}", score);
+        assert!(
+            (score - 0.18).abs() < 0.001,
+            "Expected approx 0.18, got {}",
+            score
+        );
     }
 
     #[test]
     fn test_calc_entropy_single_char_type_all_diff() {
         let score = calculate_entropy("abc");
-        assert!((score - 0.378).abs() < 0.001, "Expected approx 0.378, got {}", score);
+        assert!(
+            (score - 0.378).abs() < 0.001,
+            "Expected approx 0.378, got {}",
+            score
+        );
     }
 
     #[test]
     fn test_calc_entropy_two_char_types_perfect_mix() {
         let score = calculate_entropy("a1b2");
-        assert!((score - 0.4337).abs() < 0.001, "Expected approx 0.4337, got {}", score);
+        assert!(
+            (score - 0.4337).abs() < 0.001,
+            "Expected approx 0.4337, got {}",
+            score
+        );
     }
 
     #[test]
     fn test_calc_entropy_only_other_unique() {
         let score = calculate_entropy("€α");
-         assert!((score - 0.83).abs() < 0.05, "Expected approx 0.83, got {}", score);
+        assert!(
+            (score - 0.83).abs() < 0.05,
+            "Expected approx 0.83, got {}",
+            score
+        );
     }
 }
 
@@ -275,17 +385,31 @@ mod pattern_tests {
         let pattern = "LDLS";
         let length = 10;
         let seed = None;
-        
+
         let result = generate_with_pattern(pattern, &available_chars, length, seed);
-        assert!(result.is_ok(), "Expected successful generation despite unfulfillable pattern");
-        
+        assert!(
+            result.is_ok(),
+            "Expected successful generation despite unfulfillable pattern"
+        );
+
         let password = result.unwrap();
-        assert_eq!(password.len(), length, "Password should match the requested length");
-        
+        assert_eq!(
+            password.len(),
+            length,
+            "Password should match the requested length"
+        );
+
         for c in password.chars() {
-            assert!(available_chars.contains(&c), "Password contains character not in available_chars: {}", c);
+            assert!(
+                available_chars.contains(&c),
+                "Password contains character not in available_chars: {}",
+                c
+            );
         }
-        
-        assert!(!password.chars().any(|c| c.is_ascii_digit()), "Password should not contain digits");
+
+        assert!(
+            !password.chars().any(|c| c.is_ascii_digit()),
+            "Password should not contain digits"
+        );
     }
 }


### PR DESCRIPTION
  - introduce reusable config profiles and built-in compliance policies (`windows-ad`, `pci-dss`, `nist-high`)
  - ensure policy-selected minimum lengths cannot be bypassed by later CLI overrides
  - harden diceware download (timeouts + checksum), improve clipboard error surfacing, and refresh docs/changelog for the 0.4.6 release
  - bump crate version to 0.4.6
